### PR TITLE
Add task ID visibility and get_task_details functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,17 @@ When you first use the OmniFocus MCP server:
 
 The MCP server now supports nested tasks, allowing you to create hierarchical task structures that match OmniFocus's native capabilities.
 
+### Find and Reference Tasks by ID
+
+> "Show me the details of the task 'Review quarterly report'"
+> "Create a subtask under task ID iKNpsVubKhG"
+
+With ID visibility in `dump_database` and the new `get_task_details` tool, you can now:
+- See task IDs directly in the database dump
+- Look up any task by name to get its ID
+- Use exact IDs for reliable parent-child relationships
+- Avoid ambiguity when multiple tasks have similar names
+
 ### Reorganize your projects, tasks, and tags
 > "I want every task to have an energy level tag. show me a list of all the tasks that don't have an energy level tag and your suggestions for what tag to add. I'll make any changes I think are appropriate. Then make the changes in OmniFocus."
 
@@ -96,7 +107,21 @@ Manage multiple items efficiently:
 The server currently provides these tools:
 
 ### `dump_database`
-Gets the current state of your OmniFocus database.
+Gets the current state of your OmniFocus database. Now includes task and project IDs in the output for easy reference when creating nested tasks or relationships.
+
+### `get_task_details`
+Get detailed information about a specific task by ID or name.
+
+Parameters:
+- `taskId`: (Optional) The ID of the task to get details for
+- `taskName`: (Optional) The name of the task to get details for (partial match supported)
+
+This tool provides comprehensive task information including:
+- Full task properties (status, dates, flags, etc.)
+- Parent/child relationships with IDs
+- Project association
+- All associated tags
+- Complete metadata
 
 ### `add_omnifocus_task`
 Add a new task to OmniFocus.

--- a/src/server.ts
+++ b/src/server.ts
@@ -11,6 +11,7 @@ import * as removeItemTool from './tools/definitions/removeItem.js';
 import * as editItemTool from './tools/definitions/editItem.js';
 import * as batchAddItemsTool from './tools/definitions/batchAddItems.js';
 import * as batchRemoveItemsTool from './tools/definitions/batchRemoveItems.js';
+import * as getTaskDetailsTool from './tools/definitions/getTaskDetails.js';
 
 // Create an MCP server
 const server = new McpServer({
@@ -24,6 +25,13 @@ server.tool(
   "Gets the current state of your OmniFocus database",
   dumpDatabaseTool.schema.shape,
   dumpDatabaseTool.handler
+);
+
+server.tool(
+  "get_task_details",
+  "Get detailed information about a specific task by ID or name",
+  getTaskDetailsTool.schema.shape,
+  getTaskDetailsTool.handler
 );
 
 server.tool(

--- a/src/tools/definitions/dumpDatabase.ts
+++ b/src/tools/definitions/dumpDatabase.ts
@@ -56,7 +56,7 @@ function formatCompactReport(database: any, options: { hideCompleted: boolean, h
   // Add legend
   output += `FORMAT LEGEND:
 F: Folder | P: Project | •: Task | 🚩: Flagged
-Dates: [M/D] | Duration: (30m) or (2h) | Tags: <tag1,tag2>
+IDs: [abc123] | Dates: [M/D] | Duration: (30m) or (2h) | Tags: <tag1,tag2>
 Status: #next #avail #block #due #over #compl #drop\n\n`;
   
   // Map of folder IDs to folder objects for quick lookup
@@ -91,7 +91,7 @@ Status: #next #avail #block #due #over #compl #drop\n\n`;
   // Process folders recursively
   function processFolder(folder: any, level: number): string {
     const indent = '   '.repeat(level);
-    let folderOutput = `${indent}F: ${folder.name}\n`;
+    let folderOutput = `${indent}F: ${folder.name} [${folder.id}]\n`;
     
     // Process subfolders
     if (folder.subfolders && folder.subfolders.length > 0) {
@@ -142,7 +142,10 @@ Status: #next #avail #block #due #over #compl #drop\n\n`;
     // Add flag if present
     const flaggedSymbol = project.flagged ? ' 🚩' : '';
     
-    let projectOutput = `${indent}P: ${project.name}${flaggedSymbol}${statusInfo}\n`;
+    // Add project ID
+    const projectId = ` [${project.id}]`;
+    
+    let projectOutput = `${indent}P: ${project.name}${flaggedSymbol}${projectId}${statusInfo}\n`;
     
     // Process tasks in this project
     const projectTasks = database.tasks.filter((task: any) => 
@@ -230,7 +233,11 @@ Status: #next #avail #block #due #over #compl #drop\n\n`;
         break;
     }
     
-    let taskOutput = `${indent}• ${flagSymbol}${task.name}${dateInfo}${durationStr}${tagsStr}${statusStr}\n`;
+    // Add task ID (shortened to last 8 chars for readability)
+    const shortId = task.id.length > 8 ? `...${task.id.slice(-8)}` : task.id;
+    const taskId = ` [${shortId}]`;
+    
+    let taskOutput = `${indent}• ${flagSymbol}${task.name}${taskId}${dateInfo}${durationStr}${tagsStr}${statusStr}\n`;
     
     // Process subtasks
     if (task.childIds && task.childIds.length > 0) {

--- a/src/tools/definitions/getTaskDetails.ts
+++ b/src/tools/definitions/getTaskDetails.ts
@@ -1,0 +1,106 @@
+import { z } from 'zod';
+import { getTaskDetails, GetTaskDetailsParams } from '../primitives/getTaskDetails.js';
+import { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol.js';
+
+export const schema = z.object({
+  taskId: z.string().optional().describe("The ID of the task to get details for"),
+  taskName: z.string().optional().describe("The name of the task to get details for (partial match supported)")
+});
+
+export async function handler(args: z.infer<typeof schema>, extra: RequestHandlerExtra) {
+  try {
+    // Call the getTaskDetails function
+    const result = await getTaskDetails(args as GetTaskDetailsParams);
+    
+    if (result.success && result.task) {
+      // Format the task details for display
+      const task = result.task;
+      let output = `📋 **Task Details**\n\n`;
+      
+      // Basic information
+      output += `**Name:** ${task.name}\n`;
+      output += `**ID:** ${task.id}\n`;
+      output += `**Status:** ${task.taskStatus}\n`;
+      
+      // Flags and properties
+      if (task.flagged) output += `**Flagged:** 🚩 Yes\n`;
+      if (task.sequential) output += `**Sequential:** Yes\n`;
+      if (task.completedByChildren) output += `**Completed by children:** Yes\n`;
+      
+      // Dates
+      if (task.dueDate) {
+        output += `**Due Date:** ${new Date(task.dueDate).toLocaleDateString()}\n`;
+      }
+      if (task.deferDate) {
+        output += `**Defer Date:** ${new Date(task.deferDate).toLocaleDateString()}\n`;
+      }
+      if (task.completionDate) {
+        output += `**Completed:** ${new Date(task.completionDate).toLocaleDateString()}\n`;
+      }
+      
+      // Time estimate
+      if (task.estimatedMinutes) {
+        const hours = Math.floor(task.estimatedMinutes / 60);
+        const minutes = task.estimatedMinutes % 60;
+        output += `**Estimated Time:** ${hours > 0 ? `${hours}h ` : ''}${minutes > 0 ? `${minutes}m` : ''}\n`;
+      }
+      
+      // Relationships
+      if (task.projectName) {
+        output += `**Project:** ${task.projectName}\n`;
+      }
+      if (task.parentTaskName) {
+        output += `**Parent Task:** ${task.parentTaskName} [${task.parentId}]\n`;
+      }
+      if (task.childTaskNames && task.childTaskNames.length > 0) {
+        output += `**Subtasks:** ${task.childTaskNames.length} tasks\n`;
+        task.childTaskNames.forEach((childName, index) => {
+          output += `  - ${childName} [${task.childIds[index]}]\n`;
+        });
+      }
+      
+      // Tags
+      if (task.tagNames && task.tagNames.length > 0) {
+        output += `**Tags:** ${task.tagNames.join(', ')}\n`;
+      }
+      
+      // Note
+      if (task.note) {
+        output += `\n**Note:**\n${task.note}\n`;
+      }
+      
+      // Additional metadata
+      output += `\n**Metadata:**\n`;
+      output += `- Has Children: ${task.hasChildren ? 'Yes' : 'No'}\n`;
+      output += `- Active: ${task.active ? 'Yes' : 'No'}\n`;
+      if (task.repetitionRule) {
+        output += `- Repeating: Yes (${task.repetitionRule})\n`;
+      }
+      
+      return {
+        content: [{
+          type: "text" as const,
+          text: output
+        }]
+      };
+    } else {
+      // Task not found or error
+      return {
+        content: [{
+          type: "text" as const,
+          text: `❌ ${result.error || 'Task not found'}`
+        }],
+        isError: true
+      };
+    }
+  } catch (err: unknown) {
+    const error = err as Error;
+    return {
+      content: [{
+        type: "text" as const,
+        text: `Error getting task details: ${error.message}`
+      }],
+      isError: true
+    };
+  }
+}

--- a/src/tools/primitives/getTaskDetails.ts
+++ b/src/tools/primitives/getTaskDetails.ts
@@ -1,0 +1,124 @@
+import { OmnifocusTask, OmnifocusDatabase } from '../../types.js';
+import { dumpDatabase } from '../dumpDatabase.js';
+
+// Interface for task details parameters
+export interface GetTaskDetailsParams {
+  taskId?: string;
+  taskName?: string;
+}
+
+// Interface for the response
+export interface TaskDetailsResponse {
+  success: boolean;
+  task?: OmnifocusTask & {
+    projectName?: string;
+    parentTaskName?: string;
+    childTaskNames?: string[];
+    tagNames?: string[];
+  };
+  error?: string;
+}
+
+/**
+ * Get detailed information about a specific task
+ */
+export async function getTaskDetails(params: GetTaskDetailsParams): Promise<TaskDetailsResponse> {
+  try {
+    // Validate that at least one parameter is provided
+    if (!params.taskId && !params.taskName) {
+      return {
+        success: false,
+        error: "Either taskId or taskName must be provided"
+      };
+    }
+
+    // Get the current database
+    const database: OmnifocusDatabase = await dumpDatabase();
+
+    // Find the task
+    let task: OmnifocusTask | undefined;
+    
+    if (params.taskId) {
+      // Search by ID (exact match)
+      task = database.tasks.find(t => t.id === params.taskId);
+    } else if (params.taskName) {
+      // Search by name (case-insensitive partial match)
+      const searchName = params.taskName.toLowerCase();
+      const matches = database.tasks.filter(t => 
+        t.name.toLowerCase().includes(searchName)
+      );
+      
+      if (matches.length === 0) {
+        return {
+          success: false,
+          error: `No task found matching name: "${params.taskName}"`
+        };
+      } else if (matches.length > 1) {
+        // If multiple matches, try exact match first
+        const exactMatch = matches.find(t => t.name.toLowerCase() === searchName);
+        if (exactMatch) {
+          task = exactMatch;
+        } else {
+          // Return error with suggestions
+          const suggestions = matches.slice(0, 5).map(t => `"${t.name}" [${t.id}]`).join(', ');
+          return {
+            success: false,
+            error: `Multiple tasks found matching "${params.taskName}". Please be more specific or use task ID. Found: ${suggestions}${matches.length > 5 ? ` and ${matches.length - 5} more` : ''}`
+          };
+        }
+      } else {
+        task = matches[0];
+      }
+    }
+
+    if (!task) {
+      return {
+        success: false,
+        error: params.taskId 
+          ? `Task not found with ID: ${params.taskId}`
+          : `Task not found with name: ${params.taskName}`
+      };
+    }
+
+    // Enrich the task with additional information
+    const enrichedTask: TaskDetailsResponse['task'] = {
+      ...task
+    };
+
+    // Add project name if task belongs to a project
+    if (task.projectId && database.projects[task.projectId]) {
+      enrichedTask.projectName = database.projects[task.projectId].name;
+    }
+
+    // Add parent task name if task has a parent
+    if (task.parentId) {
+      const parentTask = database.tasks.find(t => t.id === task.parentId);
+      if (parentTask) {
+        enrichedTask.parentTaskName = parentTask.name;
+      }
+    }
+
+    // Add child task names if task has children
+    if (task.childIds && task.childIds.length > 0) {
+      enrichedTask.childTaskNames = task.childIds
+        .map(childId => {
+          const childTask = database.tasks.find(t => t.id === childId);
+          return childTask ? childTask.name : undefined;
+        })
+        .filter((name): name is string => name !== undefined);
+    }
+
+    // Tag names are already included in the task object
+
+    return {
+      success: true,
+      task: enrichedTask
+    };
+
+  } catch (error: any) {
+    return {
+      success: false,
+      error: error?.message || "Unknown error in getTaskDetails"
+    };
+  }
+}


### PR DESCRIPTION
## Summary

This PR adds task ID visibility to the dump_database output and introduces a new get_task_details tool to address the fundamental gap where users could set `parentTaskId` but had no way to discover task IDs.

## Problem Solved

Previously, the `parentTaskId` parameter existed but was practically unusable because:
- Task IDs were not visible in any tool output
- Users had no way to discover what IDs to use
- Creating reliable parent-child relationships was difficult

## Changes

### 🔍 ID Visibility in dump_database
- **Tasks**: Show shortened IDs for readability `[...last8chars]`
- **Projects**: Show full project IDs `[projectId]`
- **Folders**: Show full folder IDs `[folderId]`
- Updated format legend to explain ID notation

### 🎯 New get_task_details Tool
- Look up tasks by **ID** (exact match) or **name** (partial match)
- Returns comprehensive task information including:
  - All task properties (dates, flags, status, etc.)
  - Parent/child relationships with IDs
  - Project association
  - Tags and metadata
- Handles multiple matches gracefully with suggestions

### 📚 Documentation Updates
- Added use cases for ID-based workflows
- Documented the new tool with examples
- Updated dump_database description

## Example Usage

### Before (IDs invisible):
```
P: Work Projects
   • Review quarterly report #next
   • Prepare presentation #avail
```

### After (IDs visible):
```
P: Work Projects [k8sN2pQR7Hs]
   • Review quarterly report [...VubKhG] #next
   • Prepare presentation [...xY9mNp] #avail
```

### Using get_task_details:
```
get_task_details({ taskName: "Review quarterly report" })

Returns:
📋 Task Details
Name: Review quarterly report
ID: iKNpsVubKhG
Status: Next
Project: Work Projects
...
```

### Creating nested tasks with confidence:
```
add_omnifocus_task({
  name: "Add charts",
  parentTaskId: "iKNpsVubKhG"  // Now you know this ID!
})
```

## Benefits

- ✅ Makes `parentTaskId` parameter actually usable
- ✅ Enables reliable parent-child task relationships
- ✅ Reduces ambiguity when referencing tasks
- ✅ Improves workflow for complex task hierarchies
- ✅ Better visibility into OmniFocus data structure

## Testing

The changes are backward compatible and don't affect existing functionality. To test:

1. Run `dump_database` - observe IDs in output
2. Use `get_task_details` with a task name to get its full ID
3. Create a nested task using the discovered `parentTaskId`

## Related Issue

Closes #6